### PR TITLE
受講生検索

### DIFF
--- a/src/main/java/student/management/StudentManagement/controller/StudentController.java
+++ b/src/main/java/student/management/StudentManagement/controller/StudentController.java
@@ -59,6 +59,11 @@ public class StudentController {
     return service.searchStudentList();
   }
 
+  @GetMapping("/filterStudentList")
+  public List<StudentDetail> filterStudentList() {
+      return service.filterStudentDetailList();
+  }
+
   @Operation(
       summary = "受講生検索", description = "受講生一人分の詳細を検索します。idに紐づく生徒が存在しない場合エラーが発生します。",
       responses = {

--- a/src/main/java/student/management/StudentManagement/controller/StudentController.java
+++ b/src/main/java/student/management/StudentManagement/controller/StudentController.java
@@ -17,13 +17,9 @@ import java.util.Map;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.PutMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 import student.management.StudentManagement.controller.converter.StudentConverter;
+import student.management.StudentManagement.data.FilterParam;
 import student.management.StudentManagement.data.StudentCourse;
 import student.management.StudentManagement.domain.StudentDetail;
 import student.management.StudentManagement.exception.NotFoundException;
@@ -55,14 +51,10 @@ public class StudentController {
       )}
   )
   @GetMapping("/studentList")
-  public List<StudentDetail> getStudentList() throws NotFoundException {
-    return service.searchStudentList();
+  public List<StudentDetail> getStudentList(@ModelAttribute @Valid FilterParam filterParam) throws NotFoundException {
+      return service.searchStudentList(filterParam);
   }
 
-  @GetMapping("/filterStudentList")
-  public List<StudentDetail> filterStudentList() {
-      return service.filterStudentDetailList();
-  }
 
   @Operation(
       summary = "受講生検索", description = "受講生一人分の詳細を検索します。idに紐づく生徒が存在しない場合エラーが発生します。",

--- a/src/main/java/student/management/StudentManagement/controller/converter/StudentCourseConverter.java
+++ b/src/main/java/student/management/StudentManagement/controller/converter/StudentCourseConverter.java
@@ -19,7 +19,7 @@ public class StudentCourseConverter {
       applicationStatusList.forEach(applicationStatus -> {
         if (Objects.equals(studentCourse.getId(), applicationStatus.getCourseId())) {
           studentCourseWithApplicationStatus.setStudentCourse(studentCourse);
-          studentCourseWithApplicationStatus.setStatus(applicationStatus.getStatus());
+          studentCourseWithApplicationStatus.getApplicationStatus().setStatus(applicationStatus.getStatus());
         }
       });
       studentCourseWithApplicationStatusList.add(studentCourseWithApplicationStatus);

--- a/src/main/java/student/management/StudentManagement/controller/converter/StudentCourseConverter.java
+++ b/src/main/java/student/management/StudentManagement/controller/converter/StudentCourseConverter.java
@@ -13,17 +13,23 @@ public class StudentCourseConverter {
 
   public List<StudentCourseWithApplicationStatus> convertStudentCourseWithApplicationStatus(
       List<StudentCourse> studentCourseList, List<ApplicationStatus> applicationStatusList) {
+
     List<StudentCourseWithApplicationStatus> studentCourseWithApplicationStatusList = new ArrayList<>();
+
     studentCourseList.forEach(studentCourse -> {
+
       StudentCourseWithApplicationStatus studentCourseWithApplicationStatus = new StudentCourseWithApplicationStatus();
+
       applicationStatusList.forEach(applicationStatus -> {
+
         if (Objects.equals(studentCourse.getId(), applicationStatus.getCourseId())) {
           studentCourseWithApplicationStatus.setStudentCourse(studentCourse);
-          studentCourseWithApplicationStatus.getApplicationStatus().setStatus(applicationStatus.getStatus());
-        }
-      });
-      studentCourseWithApplicationStatusList.add(studentCourseWithApplicationStatus);
+          studentCourseWithApplicationStatus.setApplicationStatus(applicationStatus);
+        };
+
     });
+      studentCourseWithApplicationStatusList.add(studentCourseWithApplicationStatus);
+
+  });
     return studentCourseWithApplicationStatusList;
-  }
-}
+}}

--- a/src/main/java/student/management/StudentManagement/controller/filter/StudentFilter.java
+++ b/src/main/java/student/management/StudentManagement/controller/filter/StudentFilter.java
@@ -1,0 +1,39 @@
+package student.management.StudentManagement.controller.filter;
+
+import org.springframework.stereotype.Component;
+import student.management.StudentManagement.data.FilterParam;
+import student.management.StudentManagement.domain.StudentDetail;
+
+import java.util.List;
+import java.util.Objects;
+
+@Component
+public class StudentFilter {
+    public List<StudentDetail> filterStudentDetails(List<StudentDetail> studentDetailList, FilterParam param) {
+        if(Objects.nonNull(param.getName())) {
+            studentDetailList = studentDetailList.stream()
+                    .filter(studentDetail -> studentDetail.getStudent().getName().contains(param.getName()))
+                    .toList();
+        }
+
+        if(Objects.nonNull(param.getArea())) {
+            studentDetailList = studentDetailList.stream()
+                    .filter(studentDetail -> studentDetail.getStudent().getArea().equals(param.getArea()))
+                    .toList();
+        }
+
+        if(Objects.nonNull(param.getGender())) {
+            studentDetailList = studentDetailList.stream()
+                    .filter(studentDetail -> studentDetail.getStudent().getGender().equals(param.getGender()))
+                    .toList();
+        }
+
+        if(Objects.nonNull(param.getCourseName())) {
+            studentDetailList = studentDetailList.stream()
+                    .filter(studentDetail -> studentDetail.getStudentCourseWithApplicationStatusList().stream()
+                            .anyMatch(studentCourseWithApplicationStatus -> studentCourseWithApplicationStatus.getStudentCourse().getCourseName().equals(param.getCourseName()))
+                    ).toList();
+        }
+        return studentDetailList;
+    }
+}

--- a/src/main/java/student/management/StudentManagement/data/FilterParam.java
+++ b/src/main/java/student/management/StudentManagement/data/FilterParam.java
@@ -1,0 +1,32 @@
+package student.management.StudentManagement.data;
+
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.Getter;
+
+import java.util.Objects;
+
+@Getter
+@AllArgsConstructor
+public class FilterParam {
+
+    @Size(min = 2, max = 20, message = "氏名は2文字以上、20文字以内にしてください")
+    private String name;
+
+    @Pattern(regexp = "^(北海道|青森|岩手|宮城|秋田|山形|福島|茨城|栃木|群馬|埼玉|千葉|東京|神奈川|新潟|富山|石川|福井|山梨|長野|岐阜|静岡|愛知|三重|滋賀|京都|大阪|兵庫|奈良|和歌山|鳥取|島根|岡山|広島|山口|徳島|香川|愛媛|高知|福岡|佐賀|長崎|熊本|大分|宮崎|鹿児島|沖縄)$",
+            message = "都道府県名を正しく入力してください")
+    private String area;
+
+    @Pattern(regexp = "^(男性|女性|その他)$", message = "性別は（男性｜女性｜その他）で登録してください")
+    private String gender;
+
+    @Pattern(regexp = "^(Javaフルコース|AWSコース|デザインコース|WP副業コース|Webマーケティングコース|フロントエンドコース|映像制作コース|英会話コース)$",
+            message = "コース名は(Javaフルコース|AWSコース|デザインコース|WP副業コース|Webマーケティングコース|フロントエンドコース|映像制作コース|英会話コース)から選択してください")
+    private String courseName;
+
+    public boolean isAllFieldNull () {
+        return Objects.isNull(name) && Objects.isNull(area) && Objects.isNull(gender) && Objects.isNull(courseName);
+    }
+}

--- a/src/main/java/student/management/StudentManagement/domain/StudentCourseWithApplicationStatus.java
+++ b/src/main/java/student/management/StudentManagement/domain/StudentCourseWithApplicationStatus.java
@@ -4,6 +4,7 @@ import jakarta.validation.Valid;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import student.management.StudentManagement.data.ApplicationStatus;
 import student.management.StudentManagement.data.StudentCourse;
 
 @Data
@@ -15,5 +16,5 @@ public class StudentCourseWithApplicationStatus {
   private StudentCourse studentCourse;
 
   @Valid
-  private String status;
+  private ApplicationStatus applicationStatus;
 }

--- a/src/main/java/student/management/StudentManagement/repository/StudentRepository.java
+++ b/src/main/java/student/management/StudentManagement/repository/StudentRepository.java
@@ -5,6 +5,7 @@ import org.apache.ibatis.annotations.Mapper;
 import student.management.StudentManagement.data.ApplicationStatus;
 import student.management.StudentManagement.data.Student;
 import student.management.StudentManagement.data.StudentCourse;
+import student.management.StudentManagement.domain.StudentDetail;
 
 /**
  * 受講生テーブルと受講生コース情報テーブルと紐づくRepositoryです。
@@ -18,6 +19,8 @@ public interface StudentRepository {
    * @return 受講生一覧（全件）
    */
   List<Student> search();
+
+  List<StudentDetail> filterStudentDetail();
 
   /**
    * 受講生の検索を行います。

--- a/src/main/java/student/management/StudentManagement/service/StudentService.java
+++ b/src/main/java/student/management/StudentManagement/service/StudentService.java
@@ -50,6 +50,11 @@ public class StudentService {
     return studentConverter.convertStudentDetails(studentList, convertedStudentCourseList);
   }
 
+  public List<StudentDetail> filterStudentDetailList() {
+      List<StudentDetail> studentDetailList = repository.filterStudentDetail();
+      return studentDetailList;
+  }
+
   /**
    * 受講生詳細検索です。IDに紐づく受講生情報を取得した後、その受講生に紐づく受講生コース情報を取得して設定します。
    *
@@ -92,7 +97,7 @@ public class StudentService {
           String studentCourseId = studentCourse.getId();
           applicationStatus.setCourseId(studentCourseId);
           applicationStatus.setStatus(status);
-          studentCourseWithApplicationStatus.setStatus(status);
+          studentCourseWithApplicationStatus.getApplicationStatus().setStatus(status);
           repository.registerApplicationStatus(applicationStatus);
         });
     return studentDetail;
@@ -118,7 +123,7 @@ public class StudentService {
 
           ApplicationStatus applicationStatus = repository.searchApplicationStatus(
               studentCourse.getId());
-          applicationStatus.setStatus(studentCourseWithApplicationStatus.getStatus());
+          applicationStatus.setStatus(studentCourseWithApplicationStatus.getApplicationStatus().getStatus());
           repository.updateApplicationStatus(applicationStatus);
         }
     );

--- a/src/main/resources/mapper/StudentRepository.xml
+++ b/src/main/resources/mapper/StudentRepository.xml
@@ -11,6 +11,71 @@
     SELECT * FROM students
   </select>
 
+  <resultMap id="studentDetailMap" type="student.management.StudentManagement.domain.StudentDetail">
+
+    <association property="student" javaType="student.management.StudentManagement.data.Student">
+      <id property="id" column="s_id"/>
+      <result property="name" column="s_name"/>
+      <result property="kanaName" column="s_kana_name"/>
+      <result property="nickname" column="s_nickname"/>
+      <result property="email" column="s_email"/>
+      <result property="area" column="s_area"/>
+      <result property="age" column="s_age"/>
+      <result property="gender" column="s_gender"/>
+      <result property="remark" column="s_remark"/>
+    </association>
+
+    <collection property="studentCourseWithApplicationStatusList"
+                ofType="student.management.StudentManagement.domain.StudentCourseWithApplicationStatus">
+      <association property="studentCourse" javaType="student.management.StudentManagement.data.StudentCourse">
+        <id property="id" column="c_id"/>
+        <result property="studentId" column="c_student_id"/>
+        <result property="courseName" column="c_course_name"/>
+        <result property="courseStartAt" column="c_course_start_at"/>
+        <result property="courseEndAt" column="c_course_end_at"/>
+      </association>
+
+      <association property="applicationStatus" javaType="student.management.StudentManagement.data.ApplicationStatus">
+        <result property="id" column="aps_id"/>
+        <result property="courseId" column="aps_course_id"/>
+        <result property="status" column="aps_status"/>
+      </association>
+    </collection>
+
+  </resultMap>
+
+  <select id="filterStudentDetail" resultMap="studentDetailMap">
+    select
+
+    s.id AS s_id,
+    s.name AS s_name,
+    s.kana_name AS s_kana_name,
+    s.nickname AS s_nickname,
+    s.email AS s_email,
+    s.area AS s_area,
+    s.age AS s_age,
+    s.gender AS s_gender,
+    s.remark AS s_remark,
+
+    c.id AS c_id,
+    c.student_id AS c_student_id,
+    c.course_name AS c_course_name,
+    c.course_start_at AS c_course_start_at,
+    c.course_end_at AS c_course_end_at,
+
+    aps.id AS aps_id,
+    aps.course_id AS aps_course_id,
+    aps.status AS aps_status
+
+    from students s
+    left outer join students_courses c
+    on s.id = c.student_id
+    left outer join application_status aps
+    on c.id = aps.course_id
+
+    where s.is_deleted = 0
+  </select>
+
   <!-- 受講生の検索 -->
   <select id="searchStudent" resultType="student.management.StudentManagement.data.Student">
     SELECT * FROM students WHERE id = #{id}

--- a/src/test/java/student/management/StudentManagement/controller/StudentControllerTest.java
+++ b/src/test/java/student/management/StudentManagement/controller/StudentControllerTest.java
@@ -1,6 +1,7 @@
 package student.management.StudentManagement.controller;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -30,10 +31,7 @@ import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
-import student.management.StudentManagement.data.ApplicationStatus;
-import student.management.StudentManagement.data.Status;
-import student.management.StudentManagement.data.Student;
-import student.management.StudentManagement.data.StudentCourse;
+import student.management.StudentManagement.data.*;
 import student.management.StudentManagement.domain.StudentCourseWithApplicationStatus;
 import student.management.StudentManagement.domain.StudentDetail;
 import student.management.StudentManagement.service.StudentService;
@@ -79,7 +77,7 @@ class StudentControllerTest {
         now.plusMonths(3));
     applicationStatus = new ApplicationStatus("1", "1", Status.TEMPORARY_APPLICATION.getStatus());
     studentCourseWithApplicationStatus = new StudentCourseWithApplicationStatus(studentCourse,
-        applicationStatus.getStatus());
+        applicationStatus);
     studentCourseWithApplicationStatusList = List.of(studentCourseWithApplicationStatus);
     studentDetail = new StudentDetail(student, studentCourseWithApplicationStatusList);
   }
@@ -89,14 +87,14 @@ class StudentControllerTest {
   void 受講生詳細の一覧検索が実行したときにサービスが実行されJsonが返却されること()
       throws Exception {
     List<StudentDetail> studentDetailList = List.of(studentDetail);
-    when(service.searchStudentList()).thenReturn(studentDetailList);
+
+    when(service.searchStudentList(any(FilterParam.class))).thenReturn(studentDetailList);
     String expectedJson = mapper.writeValueAsString(studentDetailList);
 
     mockMvc.perform(get("/studentList"))
         .andExpect(status().isOk())
         .andExpect(content().json(expectedJson));
 
-    verify(service, times(1)).searchStudentList();
   }
 
   @Nested

--- a/src/test/java/student/management/StudentManagement/controller/converter/StudentConverterTest.java
+++ b/src/test/java/student/management/StudentManagement/controller/converter/StudentConverterTest.java
@@ -25,7 +25,7 @@ class StudentConverterTest {
     ApplicationStatus applicationStatus = new ApplicationStatus("1", "1",
         Status.TEMPORARY_APPLICATION.getStatus());
     StudentCourseWithApplicationStatus studentCourseWithApplicationStatus = new StudentCourseWithApplicationStatus(
-        studentCourse, applicationStatus.getStatus());
+        studentCourse, applicationStatus);
 
     List<Student> studentList = List.of(student);
     List<StudentCourseWithApplicationStatus> studentCourseWithApplicationStatusList = List.of(

--- a/src/test/java/student/management/StudentManagement/controller/converter/StudentCourseConverterTest.java
+++ b/src/test/java/student/management/StudentManagement/controller/converter/StudentCourseConverterTest.java
@@ -23,7 +23,7 @@ class StudentCourseConverterTest {
     ApplicationStatus applicationStatus = new ApplicationStatus("1", "1",
         Status.TEMPORARY_APPLICATION.getStatus());
     StudentCourseWithApplicationStatus studentCourseWithApplicationStatus = new StudentCourseWithApplicationStatus(
-        studentCourse, applicationStatus.getStatus());
+        studentCourse, applicationStatus);
 
     List<StudentCourse> studentCourseList = List.of(studentCourse);
     List<ApplicationStatus> applicationStatusList = List.of(applicationStatus);

--- a/src/test/java/student/management/StudentManagement/controller/filter/StudentFilterTest.java
+++ b/src/test/java/student/management/StudentManagement/controller/filter/StudentFilterTest.java
@@ -1,0 +1,79 @@
+package student.management.StudentManagement.controller.filter;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import student.management.StudentManagement.data.*;
+import student.management.StudentManagement.domain.StudentCourseWithApplicationStatus;
+import student.management.StudentManagement.domain.StudentDetail;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class StudentFilterTest {
+
+    private StudentFilter sut;
+
+    private Student student;
+    private StudentCourse studentCourse;
+    private ApplicationStatus applicationStatus;
+    private StudentCourseWithApplicationStatus studentCourseWithApplicationStatus;
+    private List<StudentCourse> studentCourseList;
+    private List<StudentCourseWithApplicationStatus> studentCourseWithApplicationStatusList;
+    private StudentDetail studentDetail;
+    private List<StudentDetail> studentDetailList;
+    private LocalDateTime now;
+
+    @BeforeEach
+    void before() {
+        sut = new StudentFilter();
+        createSampleStudentDetail();
+    }
+
+    private void createSampleStudentDetail() {
+        now = LocalDateTime.of(2025, 5, 6, 14, 0);
+        student = new Student("1", "山田太郎", "ヤマダタロウ", "やまちゃん",
+                "yamada@example.com", "東京", 30, "男性", null, false);
+        studentCourse = new StudentCourse("1", "1", "Javaフルコース", now,
+                now.plusMonths(3));
+        applicationStatus = new ApplicationStatus("1", "1", Status.TEMPORARY_APPLICATION.getStatus());
+        studentCourseWithApplicationStatus = new StudentCourseWithApplicationStatus(studentCourse,
+                applicationStatus);
+        studentCourseWithApplicationStatusList = List.of(studentCourseWithApplicationStatus);
+        studentDetail = new StudentDetail(student, studentCourseWithApplicationStatusList);
+        studentDetailList = List.of(studentDetail);
+    }
+
+    @Test
+    void 名前パラメータに該当する場合受講生詳細リストが返却されること() {
+        FilterParam param = new FilterParam("山田", null, null, null);
+        List<StudentDetail> actual = sut.filterStudentDetails(studentDetailList, param);
+        assertEquals(studentDetailList, actual);
+    }
+
+    void 地域パラメータに該当する場合受講生詳細リストが返却されること() {
+        FilterParam param = new FilterParam(null, "東京", null, null);
+        List<StudentDetail> actual = sut.filterStudentDetails(studentDetailList, param);
+        assertEquals(studentDetailList, actual);
+    }
+
+    void 性別パラメータに該当する場合受講生詳細リストが返却されること() {
+        FilterParam param = new FilterParam(null, null, "男性", null);
+        List<StudentDetail> actual = sut.filterStudentDetails(studentDetailList, param);
+        assertEquals(studentDetailList, actual);
+    }
+
+    void コース名パラメータに該当する場合受講生詳細リストが返却されること() {
+        FilterParam param = new FilterParam(null, null, null, "Javaフルコース");
+        List<StudentDetail> actual = sut.filterStudentDetails(studentDetailList, param);
+        assertEquals(studentDetailList, actual);
+    }
+
+    void パラメータがすべてnullの場合空のリストが返却されること() {
+        FilterParam param = new FilterParam(null, null, null, null);
+        List<StudentDetail> expected = List.of();
+        List<StudentDetail> actual = sut.filterStudentDetails(studentDetailList, param);
+        assertEquals(expected, actual);
+    }
+}

--- a/src/test/java/student/management/StudentManagement/controller/filter/StudentFilterTest.java
+++ b/src/test/java/student/management/StudentManagement/controller/filter/StudentFilterTest.java
@@ -52,26 +52,37 @@ class StudentFilterTest {
         assertEquals(studentDetailList, actual);
     }
 
+    @Test
     void 地域パラメータに該当する場合受講生詳細リストが返却されること() {
         FilterParam param = new FilterParam(null, "東京", null, null);
         List<StudentDetail> actual = sut.filterStudentDetails(studentDetailList, param);
         assertEquals(studentDetailList, actual);
     }
 
+    @Test
     void 性別パラメータに該当する場合受講生詳細リストが返却されること() {
         FilterParam param = new FilterParam(null, null, "男性", null);
         List<StudentDetail> actual = sut.filterStudentDetails(studentDetailList, param);
         assertEquals(studentDetailList, actual);
     }
 
+    @Test
     void コース名パラメータに該当する場合受講生詳細リストが返却されること() {
         FilterParam param = new FilterParam(null, null, null, "Javaフルコース");
         List<StudentDetail> actual = sut.filterStudentDetails(studentDetailList, param);
         assertEquals(studentDetailList, actual);
     }
 
-    void パラメータがすべてnullの場合空のリストが返却されること() {
+    @Test
+    void パラメータがすべてnullの場合受講生詳細リストが返却されること() {
         FilterParam param = new FilterParam(null, null, null, null);
+        List<StudentDetail> actual = sut.filterStudentDetails(studentDetailList, param);
+        assertEquals(studentDetailList, actual);
+    }
+
+    @Test
+    void パラメータに該当する情報が存在しない場合空のリストが返却されること() {
+        FilterParam param = new FilterParam("野口", null, null, null);
         List<StudentDetail> expected = List.of();
         List<StudentDetail> actual = sut.filterStudentDetails(studentDetailList, param);
         assertEquals(expected, actual);

--- a/src/test/java/student/management/StudentManagement/service/StudentServiceTest.java
+++ b/src/test/java/student/management/StudentManagement/service/StudentServiceTest.java
@@ -72,20 +72,24 @@ class StudentServiceTest {
 
   @Test
   @DisplayName("searchStudentList()の機能実装")
-  void 受講生詳細の一覧検索_パラメータがnullの場合リポジトリとコンバータの処理が適切に呼び出せていること() {
+  void 受講生詳細の一覧検索_パラメータがnullの場合リポジトリとコンバータの処理が呼び出され受講生詳細が返却されること() {
     List<Student> studentList = List.of(student);
+    List<StudentDetail> studentDetailList = List.of(studentDetail);
     when(repository.search()).thenReturn(studentList);
     when(repository.searchStudentCourseList()).thenReturn(studentCourseList);
     when(repository.searchApplicationStatusList()).thenReturn(applicationStatusList);
     when(studentCourseConverter.convertStudentCourseWithApplicationStatus(studentCourseList,
         applicationStatusList)).thenReturn(studentCourseWithApplicationStatusList);
+    when(studentConverter.convertStudentDetails(studentList, studentCourseWithApplicationStatusList))
+            .thenReturn(studentDetailList);
 
-    sut.searchStudentList(new FilterParam(null,null,null,null));
+    List<StudentDetail> actual = sut.searchStudentList(new FilterParam(null,null,null,null));
 
     verify(repository, times(1)).search();
     verify(repository, times(1)).searchStudentCourseList();
     verify(studentConverter, times(1)).convertStudentDetails(studentList,
         studentCourseWithApplicationStatusList);
+    assertEquals(studentDetailList, actual);
   }
 
   @Test
@@ -103,13 +107,15 @@ class StudentServiceTest {
     when(studentFilter.filterStudentDetails(studentDetailList, param))
             .thenReturn(studentDetailList);
 
-    sut.searchStudentList(param);
+    List<StudentDetail> actual = sut.searchStudentList(param);
 
     verify(repository, times(1)).search();
     verify(repository, times(1)).searchStudentCourseList();
     verify(studentConverter, times(1)).convertStudentDetails(studentList,
             studentCourseWithApplicationStatusList);
     verify(studentFilter, times(1)).filterStudentDetails(studentDetailList, param);
+
+    assertEquals(studentDetailList, actual);
   }
 
   @Test


### PR DESCRIPTION
# 課題内容
検索機能の実装

# 実装内容
[3d6d54b](https://github.com/taiki1010/StudentManagement/pull/29/commits/3d6d54b4f761c885d7fcc36de34153ea45a8f293)
既存の受講生全件を取得できる機能を修正して実装しました。
リクエストパラメータでユーザーから入力された検索条件のデータを取得しています。
検索条件は下記の４つです
・受講生の名前（部分一致）
・地域（完全一致）
・性別（完全一致）
・コース名（完全一致）

# 実行結果
**・リクエストパラメータに何もない場合、全件取得すること**
<img width="1045" alt="スクリーンショット 2025-05-19 16 36 21" src="https://github.com/user-attachments/assets/4e58c910-f3c7-4698-b1f4-bd30aeb3a39b" />

**・リクエストパラメータの条件に合うデータのみ取得すること**
<img width="1048" alt="スクリーンショット 2025-05-19 16 36 56" src="https://github.com/user-attachments/assets/d12e6ffa-80e8-4de1-9e5f-cb256b8972a0" />

**・条件に一致したデータが存在しない場合、エラーメッセージを返すこと**
<img width="1049" alt="スクリーンショット 2025-05-19 16 38 11" src="https://github.com/user-attachments/assets/52f36bc9-6623-47d0-a2e0-dfeb548bbd51" />

**・リクエストパラメータにバリデーションチェックがかかること**
<img width="1055" alt="スクリーンショット 2025-05-19 16 39 16" src="https://github.com/user-attachments/assets/465cb39d-a4ac-40b7-972f-eb3782e1d1bf" />

